### PR TITLE
Remove caskroom as no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ First, you'll have to have [Homebrew](http://brew.sh) installed.
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-Then install [Caskroom](http://caskroom.io).
-
-    brew install caskroom/cask/brew-cask
-
 Then tap this repository.
 
     brew tap colindean/fonts-nonfree

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Non-Free Fonts
 
-This [Homebrew](http://brew.sh)/[Caskroom](http://caskroom.io) tap contains
+This [Homebrew](http://brew.sh) tap contains
 various non-free fonts from around the Internet.
 
 ## License and copyright


### PR DESCRIPTION
I was running through this today and saw that the stuff relating to Caskroom (and the associated website link) is no longer required, so I thought I would update the readme. Hope that is ok.